### PR TITLE
Fix pluralization in create_order test comment

### DIFF
--- a/create_order.py
+++ b/create_order.py
@@ -66,7 +66,7 @@ def main():
         
 
         
-        # Create test order with 1 items
+        # Create test order with 1 item
         order_data = {
             "customer_name": "Test Customer",
             "customer_email": "test@example.com",


### PR DESCRIPTION
## Summary
- correct pluralization in test order comment in `create_order.py`

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'core')

------
https://chatgpt.com/codex/tasks/task_e_689dbefa1b4c832cb0ef90998df70c2f