### PR TITLE
Use safe version lookup in metadata constraints test

### DIFF
--- a/test_metadata_api_extended.py
+++ b/test_metadata_api_extended.py
@@ -158,12 +158,15 @@ class TestMetadataAPIExtended(unittest.TestCase):
         # Verify constraints are preserved
         metadata = self.api.get_metadata("test/constraints")
         self.assertIsNotNone(metadata)
-        version = metadata["versions"][0]
+        version = next(iter(metadata["versions"].values()))
+        age_field = version["fields"]["age"]
+        self.assertEqual(age_field["constraints"]["min"], 0)
+        self.assertEqual(age_field["constraints"]["max"], 150)
+        email_field = version["fields"]["email"]
         self.assertEqual(
-            version["fields"][0]["constraints"]["max"],
-            150
+            email_field["constraints"]["pattern"],
+            r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         )
-        self.assertIn("pattern", version["fields"][1]["constraints"])
         
     def test_invalid_node_type(self):
         """Test creating metadata with invalid node type."""


### PR DESCRIPTION
## Summary
- Use safe version lookup when checking constraints in metadata test
- Assert min, max, and pattern constraints to ensure they persist

## Testing
- `PYTHONPATH=$PWD pytest test_metadata_api_extended.py::TestMetadataAPIExtended::test_metadata_with_constraints -q`
- `PYTHONPATH=$PWD pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_689dbef34db4832ca17e5730b645b7c7